### PR TITLE
Introduce Rule nodes and update KG utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ ClearSure is an open-source AI built for context-aware, definitive insights like
 # Some binaries have to be manually installed
 1. powershell choco install poppler
 2. powershell choco install tesseract
+
+## Knowledge Graph Architecture
+
+Documents are ingested and converted to a two-layer knowledge graph:
+
+1. **Statement layer** – Every sentence-level fact is preserved as a
+   `:Statement` node. This forms an immutable audit trail of the source text.
+
+2. **Company view** – Cleaned entities and their relations build the
+   operational view of the "brain". Logical rules are explicit `:Rule` nodes
+   connected to statements via `:HAS_CONDITION` and `:HAS_CONCLUSION` edges.
+
+This design keeps logical operators out of entity space while making it easy to
+traverse from conditions to conclusions.

--- a/transformation/LLMs.py
+++ b/transformation/LLMs.py
@@ -145,12 +145,15 @@ NODE-RULES
 2. **Time-anchor nodes** (all wN lines)  
    • Shape:  {{ "id":"wN", "label":"<full time phrase>" }}
 
-3. **Statement surrogate nodes**  
-   • One per Fact (not for Alias / Quantity / IF-THEN).  
-   • Copy the full Fact text into  "label".  
-   • Add  "type":"Statement"  and  "edgeId":"e_sN".  
+3. **Statement surrogate nodes**
+   • One per Fact (not for Alias / Quantity / IF-THEN).
+   • Copy the full Fact text into  "label".
+   • Add  "type":"Statement"  and  "edgeId":"e_sN".
    • Shape:  {{ "id":"sN", "label":"<fact text>", "type":"Statement",
                "edgeId":"e_sN" }}
+
+4. **Rule nodes** for IF/THEN lines
+   • Shape:  {{ "id":"rN", "label":"<rule text>", "type":"Rule" }}
 
 -----------------------------------------------------------------
 EDGE-RULES
@@ -170,10 +173,12 @@ C. **WHEN edges**
    • For any “… [WHEN = wN]” tag attach  
      {{ "source":"sN", "relation":"WHEN", "target":"wN" }}
 
-D. **Logic edges** from IF / THEN lines  
-   • Use  "relation":"CAUSES"  
-   • Example  
-     {{ "source":"s3", "relation":"CAUSES", "target":"s5" }}
+D. **Rule edges** linking Rule nodes to Statements
+   • For each IF/THEN line create one Rule node rN.
+   • Connect it with {{ "source":"rN", "relation":"HAS_CONDITION", "target":"sX" }}
+     for every condition statement, and
+     {{ "source":"rN", "relation":"HAS_CONCLUSION", "target":"sY" }}
+     for every conclusion statement.
 
 -----------------------------------------------------------------
 NAMING & CONSISTENCY
@@ -205,7 +210,8 @@ s4 - the test occurs [WHEN = w1].
     {{"id":"w1","label":"at 09:00 UTC"}},
     {{"id":"s1","label":"Ada Lovelace waited seven minutes.","type":"Statement","edgeId":"e_s1"}},
     {{"id":"s2","label":"Ada Lovelace fired at 1 kHz.","type":"Statement","edgeId":"e_s2"}},
-    {{"id":"s4","label":"the test occurs","type":"Statement","edgeId":"e_s4"}}
+    {{"id":"s4","label":"the test occurs","type":"Statement","edgeId":"e_s4"}},
+    {{"id":"r1","label":"IF [s1] THEN [s2]","type":"Rule"}}
   ],
   "edges":[
     {{"source":"n1","relation":"waited","target":"n2","edgeId":"e_s1"}},
@@ -221,7 +227,8 @@ s4 - the test occurs [WHEN = w1].
     {{"source":"w1","relation":"OBJECT_IN","target":"s4"}},
     {{"source":"s4","relation":"WHEN","target":"w1"}},
 
-    {{"source":"s1","relation":"CAUSES","target":"s2"}}
+    {{"source":"r1","relation":"HAS_CONDITION","target":"s1"}},
+    {{"source":"r1","relation":"HAS_CONCLUSION","target":"s2"}}
   ]
 }}
 

--- a/transformation/convert.py
+++ b/transformation/convert.py
@@ -34,11 +34,13 @@ for node in kg["nodes"]:
         continue
     node_ids.add(nid)
 
-    props = {k: v for k, v in node.items() if k not in ["id", "label"]}
+    props = {k: v for k, v in node.items() if k not in ["id", "label", "type"]}
     # Also handle nested attributes
     if "attributes" in props:
         attrs = props.pop("attributes")
         props.update(attrs)
+
+    node_label = node.get("type", "Entity")
 
     prop_str = ""
     if props:
@@ -46,7 +48,7 @@ for node in kg["nodes"]:
         prop_str = ", " + ", ".join(prop_pairs)
 
     cypher_nodes.append(
-        f'CREATE (:Entity {{id: "{nid}", label: "{label}"{prop_str}}});'
+        f'CREATE (:{clean_relation(node_label)} {{id: "{nid}", label: "{label}"{prop_str}}});'
     )
 
 for edge in kg["edges"]:


### PR DESCRIPTION
## Summary
- add Rule node architecture to docs
- update knowledge graph prompt to output Rule nodes
- allow dynamic node labels when exporting to Cypher
- extend KG utilities for Rule nodes and convert CAUSES edges

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a761aea80832c93168f934fc99d78