### PR TITLE
Fix KeyError when converting KG

### DIFF
--- a/transformation/convert.py
+++ b/transformation/convert.py
@@ -27,7 +27,10 @@ node_ids = set()
 # Here: NO "for graph in kg"
 for node in kg["nodes"]:
     nid = node["id"]
-    label = escape(node["label"])
+    # Not all nodes are guaranteed to carry a `label` field.  If it's
+    # missing we fall back to an empty string so the conversion still
+    # succeeds rather than failing with a KeyError.
+    label = escape(node.get("label", ""))
 
     # Avoid duplicating the same node
     if nid in node_ids:


### PR DESCRIPTION
## Summary
- avoid KeyError in `convert.py` when some nodes miss `label`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e2258ecf4832c86b3ec478da841ae