### PR TITLE
Fix GLOBAL_LLM initialization

### DIFF
--- a/transformation/main.py
+++ b/transformation/main.py
@@ -11,9 +11,9 @@ from pipeline import (
     OUT_PATH,
     INPUT_PATH
 )
+import summary_logic
 from summary_logic import (
     LLMWrapper,
-    GLOBAL_LLM,
     build_tree,
     OUTPUT_JSON_PATH,
 )
@@ -48,7 +48,7 @@ def phase2_summary(text_path: Path) -> None:
     """Run phase 2: build summary tree and merge into KG."""
     llm = LLMWrapper(backend="ollama", model_name="deepseek-r1:14b")
     # register globally for helper functions in summary_logic
-    globals()['GLOBAL_LLM'] = llm
+    summary_logic.GLOBAL_LLM = llm
 
     full_text = text_path.read_text(encoding="utf-8")
     root = build_tree(full_text)


### PR DESCRIPTION
## Summary
- import the entire `summary_logic` module
- fix GLOBAL_LLM assignment so helper functions use the initialized model

## Testing
- `pytest -q`
- `python -m py_compile transformation/main.py transformation/summary_logic.py transformation/LLMs.py`
- `python transformation/main.py --help` *(fails: ModuleNotFoundError: No module named 'langchain_ollama')*

------
https://chatgpt.com/codex/tasks/task_e_687e37df8874832ca95f8c9cf4e323be