### PR TITLE
Fix doc_tree env var init

### DIFF
--- a/transformation/doc_tree.py
+++ b/transformation/doc_tree.py
@@ -13,6 +13,18 @@ from pathlib import Path
 from typing import List
 from uuid import uuid4
 
+try:
+    # load environment variables from .env file (requires `python-dotenv`)
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # pragma: no cover - optional dependency
+    pass
+
+os.environ["OLLAMA_HOST"] = os.environ.get(
+    "OLLAMA_HOST_PC", os.environ.get("OLLAMA_HOST", "")
+)
+
 import nltk
 import pdfplumber
 from neo4j import GraphDatabase


### PR DESCRIPTION
## Summary
- load environment variables via `dotenv` in `doc_tree.py`
- default `OLLAMA_HOST` to the desktop host if provided

## Testing
- `python -m py_compile transformation/doc_tree.py`

------
https://chatgpt.com/codex/tasks/task_e_687e4ce8d6e4832cbc99140351c99bd1