### PR TITLE
Fix doc_tree API URL handling

### DIFF
--- a/transformation/doc_tree.py
+++ b/transformation/doc_tree.py
@@ -94,7 +94,9 @@ def call_with_backoff(
                 res = openai.ChatCompletion.create(**kwargs)
                 return res["choices"][0]["message"]["content"].strip()
             else:  # ollama
-                url = base_url or "http://localhost:11434/api/chat"
+                url = base_url or "http://localhost:11434/api/generate"
+                if not url.rstrip("/").endswith(("api/chat", "api/generate")):
+                    url = url.rstrip("/") + "/api/generate"
                 resp = requests.post(
                     url,
                     json={"model": model, "messages": messages, "stream": False},


### PR DESCRIPTION
## Summary
- ensure Ollama base URLs automatically append `/api/generate`

## Testing
- `python -m py_compile transformation/doc_tree.py`


------
https://chatgpt.com/codex/tasks/task_e_687f7e79a234832c9a6cb58a4f683afa