### PR TITLE
Align doc_tree with LLM helper module

### DIFF
--- a/transformation/LLMs.py
+++ b/transformation/LLMs.py
@@ -433,3 +433,22 @@ Create **two** coherent segments that together cover **all** characters in <INPU
         raise ValueError("Spans do not cover entire text.")
 
     return spans
+
+
+def label_text(text: str, model) -> str:
+    """Return a short label describing *text*."""
+    prompt_template = PromptTemplate.from_template(
+        "Give a concise node label (<= 12 words) describing the following text:\n\n{text}"
+    )
+    prompt = prompt_template.format(text=text)
+    return model.invoke(prompt)
+
+
+def sentence_topic_same(topic: str, sentence: str, model) -> bool:
+    """Determine whether *sentence* elaborates on *topic*."""
+    prompt_template = PromptTemplate.from_template(
+        "Topic: {topic}\nSentence: {sentence}\nDoes the sentence elaborate on this topic? Answer yes or no."
+    )
+    prompt = prompt_template.format(topic=topic, sentence=sentence)
+    reply = model.invoke(prompt)
+    return reply.lower().startswith("yes")


### PR DESCRIPTION
## Summary
- centralize doc_tree prompts inside `LLMs.py`
- import `label_text` and `sentence_topic_same` in doc_tree
- truncate text locally before calling shared helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687f9b4532a8832ca4ee5e7da1609281