### PR TITLE
Clean node labels

### DIFF
--- a/transformation/LLMs.py
+++ b/transformation/LLMs.py
@@ -246,6 +246,18 @@ def remove_think_block(text: str) -> str:
     # Remove <think>...</think> including the tags
     return re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL)
 
+
+def clean_label(text: str) -> str:
+    """Return *text* without think blocks, quotes, or markup prefixes."""
+    text = remove_think_block(text).strip()
+    # Remove leading 'Node Label:' or 'Label:' style prefixes
+    text = re.sub(r'^(?:node\s*label|label)\s*:\s*', "", text, flags=re.I)
+    # Strip common quote or emphasis markers
+    if text.startswith("**") and text.endswith("**"):
+        text = text[2:-2]
+    text = text.strip("\"'`*")
+    return text.strip()
+
 def clean_up_1st_phase(text: str, model):
     prompt_template = PromptTemplate.from_template(
         """

--- a/transformation/doc_tree.py
+++ b/transformation/doc_tree.py
@@ -27,7 +27,7 @@ import nltk
 import pdfplumber
 from neo4j import GraphDatabase
 from langchain_ollama.llms import OllamaLLM
-from LLMs import label_text, sentence_topic_same, remove_think_block
+from LLMs import label_text, sentence_topic_same, clean_label
 
 VERBOSE = False
 
@@ -122,7 +122,7 @@ def phase2(
     raw_label = label_text(_ensure_length(first_sentence, ctx_limit), model)
     if "<think>" in raw_label and VERBOSE:
         print(raw_label)
-    label = remove_think_block(raw_label).strip()
+    label = clean_label(raw_label)
     end = first_end
     for i in range(1, len(spans)):
         sent = text[spans[i][0] : spans[i][1]]
@@ -156,7 +156,7 @@ def build_tree(text: str, model) -> Node:
     raw_root = label_text(_ensure_length(text, ctx // 2), model)
     if "<think>" in raw_root and VERBOSE:
         print(raw_root)
-    root_name = remove_think_block(raw_root).strip()
+    root_name = clean_label(raw_root)
     log(f"🌲 Root topic: {root_name}")
     root = Node(name=root_name, char_start=0, char_end=len(text) - 1, parent=None)
     phase2(text, root, 0, model, ctx // 2)


### PR DESCRIPTION
## Summary
- standardize node label format from LLM output
- remove leftover imports in doc_tree

## Testing
- `python3 -m py_compile transformation/LLMs.py transformation/doc_tree.py`

------
https://chatgpt.com/codex/tasks/task_e_687fa3bc24b8832c84cb08ebb032fd3b