### PR TITLE
Add topic tree generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ ClearSure is an open-source AI built for context-aware, definitive insights like
 # Some binaries have to be manually installed
 1. powershell choco install poppler
 2. powershell choco install tesseract
+
+## Topic extraction
+After processing all sentences, the pipeline derives a concise topic label from
+the document’s statements. The topic node (`t#`) is linked to the first
+statement via the relation `BELONGS_TO_TOPIC`.

--- a/transformation/kg_utils.py
+++ b/transformation/kg_utils.py
@@ -8,9 +8,9 @@ from copy import deepcopy
 _EDGE = Tuple[str, str, str]
 
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.I)
-_ID_PREFIX_RE  = re.compile(r"^([nsw])(\d+)$")
+_ID_PREFIX_RE  = re.compile(r"^([nswt])(\d+)$")
 _EDGE_ID_RE    = re.compile(r"^e(\d+)$")
-_BRACKET_REF_RE = re.compile(r"\[(n\d+|s\d+|w\d+)\]")
+_BRACKET_REF_RE = re.compile(r"\[(n\d+|s\d+|w\d+|t\d+)\]")
 
 def _strip_fence(text: str) -> str:
     """Remove ```json fences and surrounding blank lines."""
@@ -176,7 +176,7 @@ def update_kg(
     patch_nodes = _load_patch(new_kg, "nodes")
     patch_edges = _load_patch(new_kg, "edges")
 
-    node_counters = {p: _max_index(kg["nodes"], p) for p in ("n", "s", "w")}
+    node_counters = {p: _max_index(kg["nodes"], p) for p in ("n", "s", "w", "t")}
     edge_counter  = [_max_edge_index(kg["edges"])]
 
     id_map: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- generate topic nodes after processing sentences
- ensure `kg_utils` understands topic IDs
- document new topic extraction step

## Testing
- `python -m py_compile transformation/pipeline.py transformation/kg_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687fb1e11eb8832cbb4f43441cb6f8b1