### PR TITLE
Add topic tree integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,9 @@ Documents are ingested and converted to a two-layer knowledge graph:
    operational view of the "brain". Logical rules are explicit `:Rule` nodes
    connected to statements via `:HAS_CONDITION` and `:HAS_CONCLUSION` edges.
 
+3. **Topic layer** – After processing all statements, related sentences are
+   summarised into short topics (`t#`). Statement nodes link to these topics via
+   `BELONGS_TO_TOPIC`, providing a lightweight navigation hierarchy.
+
 This design keeps logical operators out of entity space while making it easy to
 traverse from conditions to conclusions.


### PR DESCRIPTION
## Summary
- support Topic (`t#`) node IDs in `kg_utils`
- generate topic nodes from statements in `pipeline`
- attach statements to topics after KG construction
- document topic layer in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688099e321e4832cb309bdac649d1624