### PR TITLE
Add topic tree flattening to populate KG with topics

### DIFF
--- a/transformation/doc_tree.py
+++ b/transformation/doc_tree.py
@@ -91,6 +91,35 @@ class Node:
         }
 
 
+def flatten_tree(root: "Node") -> tuple[list[dict], list[dict]]:
+    """Return all topic nodes and HAS_CHILD edges from ``root``.
+
+    The output can be fed directly into ``update_kg``/``clean_kg`` helpers.
+    """
+
+    nodes: list[dict] = []
+    edges: list[dict] = []
+
+    def _walk(node: Node) -> None:
+        nodes.append(
+            {
+                "id": node.id,
+                "label": node.name,
+                "type": "Topic",
+                "char_start": node.char_start,
+                "char_end": node.char_end,
+            }
+        )
+        for child in node.children:
+            edges.append(
+                {"source": node.id, "relation": "HAS_CHILD", "target": child.id}
+            )
+            _walk(child)
+
+    _walk(root)
+    return nodes, edges
+
+
 # ---------------------------------------------------------------------------
 # Topic discovery
 # ---------------------------------------------------------------------------

--- a/transformation/main.py
+++ b/transformation/main.py
@@ -82,6 +82,11 @@ def phase2_summary(text_path: Path) -> None:
 
     reset_final_kg(FINAL_KG_PATH, backup=False, verbose=VERBOSE)
 
+    # Insert Topic nodes into the KG before linking statements to them
+    topic_nodes, child_edges = doc_tree.flatten_tree(tree)
+    if topic_nodes or child_edges:
+        update_kg({"nodes": topic_nodes, "edges": child_edges}, kg_path=FINAL_KG_PATH)
+
     sentence_kgs = json.loads(SENTENCE_KGS_PATH.read_text(encoding="utf-8"))
 
     for sent in sentence_kgs:


### PR DESCRIPTION
## Summary
- support flattening a topic tree into node/edge lists
- load topic nodes into the KG before linking statements during phase 2

## Testing
- `python -m py_compile transformation/doc_tree.py transformation/main.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6880a25be904832cbfe898111170e49c