### PR TITLE
Simplify topic links to rules

### DIFF
--- a/transformation/main.py
+++ b/transformation/main.py
@@ -18,7 +18,7 @@ from pipeline import (
 )
 from run_pipeline import load_and_push, clear_database
 import doc_tree
-from kg_utils import update_kg, clean_kg
+from kg_utils import update_kg, clean_kg, consolidate_rules_to_topics
 
 VERBOSE = False
 
@@ -106,6 +106,11 @@ def phase2_summary(text_path: Path) -> None:
                     })
         if edges:
             clean_kg({"edges_patch": edges}, kg_path=FINAL_KG_PATH)
+
+    # Simplify topic links by attaching rules directly to their topics
+    kg = json.loads(FINAL_KG_PATH.read_text(encoding="utf-8"))
+    kg = consolidate_rules_to_topics(kg)
+    FINAL_KG_PATH.write_text(json.dumps(kg, indent=2), encoding="utf-8")
 
     return None
 


### PR DESCRIPTION
## Summary
- consolidate rules that reference statements in the same topic
- attach those rules directly to the topic and drop redundant statement links

## Testing
- `python -m py_compile transformation/LLMs.py transformation/doc_tree.py transformation/main.py transformation/kg_utils.py transformation/pipeline.py transformation/sentence_kgs.py ingestion/ingestion.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a84e0cc0832c80d91721a81fcd4c