### PR TITLE
Make Ollama model name configurable

### DIFF
--- a/transformation/main.py
+++ b/transformation/main.py
@@ -11,8 +11,9 @@ OUT_PATH = STRUCTURED_DIR / "import_kg.cypher"
 
 def main() -> None:
     os.environ["OLLAMA_HOST"] = os.environ.get("OLLAMA_HOST_PC", os.environ.get("OLLAMA_HOST", ""))
+    model_name = os.environ.get("OLLAMA_MODEL", "deepseek-r1:14b")
     model = OllamaLLM(
-        model="deepseek-r1:14b",
+        model=model_name,
         base_url=os.environ["OLLAMA_HOST"],
         options={"num_ctx": 8192},
         temperature=0.0,

--- a/transformation/pipeline.py
+++ b/transformation/pipeline.py
@@ -66,8 +66,9 @@ def process_document(model, input_file: str = "output.json") -> Dict[str, Any]:
 # ------------------------------------------------------------------
 if __name__ == "__main__":
     os.environ["OLLAMA_HOST"] = os.environ["OLLAMA_HOST_PC"]
+    model_name = os.environ.get("OLLAMA_MODEL", "deepseek-r1:14b")
     model = OllamaLLM(
-        model="deepseek-r1:14b",
+        model=model_name,
         base_url=os.environ["OLLAMA_HOST"],
         options={"num_ctx": 8192},
         temperature=0.0,


### PR DESCRIPTION
## Summary
- allow overriding the Ollama model with `OLLAMA_MODEL` in `main.py` and `pipeline.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f19d115c832cac80e528449f128c