### PR TITLE
feat: add Google Gemini LLM support

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,6 +15,7 @@ pydantic>=2.7,<3                  # schema validation
 langchain-core==0.2.*             # prompt objects & flow control
 langchain-community==0.2.*        # ready-made output parsers
 langchain-ollama==0.1.*           # thin wrapper around Ollama’s REST
+langchain-google-genai==0.0.*     # Google Gemini support
 
 # ---- transient compatibility pins ----
 packaging<24      # many libs still cap here

--- a/requirements.txt
+++ b/requirements.txt
@@ -262,6 +262,7 @@ langchain-core==0.2.43
     #   langchain-ollama
     #   langchain-text-splitters
 langchain-ollama==0.1.3
+langchain-google-genai
     # via -r requirements.in
 langchain-text-splitters==0.2.4
     # via langchain

--- a/transformation/llm.py
+++ b/transformation/llm.py
@@ -1,0 +1,36 @@
+import os
+from typing import Any
+
+
+def build_llm() -> Any:
+    """Return an LLM instance based on environment configuration.
+
+    Defaults to using Google's Gemini models. Set the environment variable
+    ``LLM_PROVIDER`` to ``"ollama"`` to use an Ollama-backed model instead.
+    For Gemini, the API key is read from ``GEMINI_API_KEY`` or
+    ``GOOGLE_API_KEY``. For Ollama, ``OLLAMA_HOST`` or ``OLLAMA_HOST_PC`` must
+    be set.
+    """
+    provider = os.getenv("LLM_PROVIDER", "google").lower()
+
+    if provider == "ollama":
+        from langchain_ollama.llms import OllamaLLM
+
+        host = os.environ.get("OLLAMA_HOST") or os.environ.get("OLLAMA_HOST_PC")
+        if not host:
+            raise EnvironmentError("Set OLLAMA_HOST or OLLAMA_HOST_PC")
+        model_name = os.environ.get("OLLAMA_MODEL", "deepseek-r1:14b")
+        return OllamaLLM(
+            model=model_name,
+            base_url=host,
+            options={"num_ctx": 8192},
+            temperature=0.0,
+        )
+
+    from langchain_google_genai import GoogleGenerativeAI
+
+    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        raise EnvironmentError("Set GEMINI_API_KEY or GOOGLE_API_KEY")
+    model_name = os.environ.get("GEMINI_MODEL", "gemini-1.5-pro-latest")
+    return GoogleGenerativeAI(model=model_name, google_api_key=api_key, temperature=0.0)

--- a/transformation/pipeline.py
+++ b/transformation/pipeline.py
@@ -1,13 +1,12 @@
 # ------------------------------------------------------------------
 # 0.  utilities ----------------------------------------------------
 # ------------------------------------------------------------------
-import json, os
+import json
 from pathlib import Path
 from typing import Dict, Any, Iterable
 import spacy, warnings
 import argparse
 import pdfplumber
-from langchain_ollama.llms import OllamaLLM
 from kg_utils import _extract_json_block, update_kg, clean_kg
 from LLMs import (
     simplify_text,
@@ -17,6 +16,7 @@ from LLMs import (
     label_text,
     clean_label,
 )
+from llm import build_llm
 
 try:
     # load environment variables from .env file (requires `python-dotenv`)
@@ -267,16 +267,7 @@ if __name__ == "__main__":
     parser.add_argument("path", type=Path, help="Path to a PDF or text file to process")
     args = parser.parse_args()
 
-    os.environ["OLLAMA_HOST"] = os.environ.get(
-        "OLLAMA_HOST_PC", os.environ.get("OLLAMA_HOST", "")
-    )
-
-    model = OllamaLLM(
-        model="deepseek-r1:14b",
-        base_url=os.environ["OLLAMA_HOST"],
-        options={"num_ctx": 8192},
-        temperature=0.0,
-    )
+    model = build_llm()
 
     input_file = prepare_input_file(args.path)
 

--- a/transformation/sentence_kgs.py
+++ b/transformation/sentence_kgs.py
@@ -1,9 +1,8 @@
 import json
-import os
 from pathlib import Path
 import argparse
 
-from langchain_ollama.llms import OllamaLLM
+from llm import build_llm
 
 from LLMs import simplify_text, remove_think_block, create_knowledge_ontology
 from kg_utils import _extract_json_block
@@ -12,18 +11,6 @@ from pipeline import split_into_sentences, extract_text
 BASE_DIR = Path(__file__).resolve().parents[1]
 STRUCTURED_DIR = BASE_DIR / "structured"
 STRUCTURED_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def build_model() -> OllamaLLM:
-    host = os.environ.get("OLLAMA_HOST") or os.environ.get("OLLAMA_HOST_PC")
-    if not host:
-        raise EnvironmentError("Set OLLAMA_HOST or OLLAMA_HOST_PC")
-    return OllamaLLM(
-        model="deepseek-r1:14b",
-        base_url=host,
-        options={"num_ctx": 8192},
-        temperature=0.0,
-    )
 
 
 def sentence_kgs(text: str, model) -> list[dict]:
@@ -39,7 +26,7 @@ def sentence_kgs(text: str, model) -> list[dict]:
 
 def main(path: Path, out: Path) -> None:
     text = extract_text(path)
-    model = build_model()
+    model = build_llm()
     kgs = sentence_kgs(text, model)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(kgs, indent=2, ensure_ascii=False), encoding="utf-8")


### PR DESCRIPTION
## Summary
- add `build_llm` helper to create Gemini (default) or Ollama models based on env vars
- switch transformation scripts to use `build_llm` so pipelines can toggle model provider
- document new dependency on `langchain-google-genai`

## Testing
- `pytest`
- `pip install pip-tools` *(failed: Could not find a version that satisfies the requirement pip-tools)*

------
https://chatgpt.com/codex/tasks/task_e_6891e41c3cdc832cac32ffca8db7bee0