### PR TITLE
Handle missing ontology output

### DIFF
--- a/transformation/pipeline.py
+++ b/transformation/pipeline.py
@@ -224,11 +224,20 @@ def process_document(model, input_file: str = "output.json") -> list[dict]:
         # ------------------------------------------------------
         # (C) clean-up first pass
         # ------------------------------------------------------
-        kg_patch_dict = json.loads(_extract_json_block(kg_patch_txt))
+        try:
+            kg_patch_dict = json.loads(_extract_json_block(kg_patch_txt))
+        except ValueError as e:
+            print(f"⚠️ Skipping sentence; could not parse ontology JSON: {e}")
+            continue
+
         cleaned_patch_txt = remove_think_block(clean_up_1st_phase(kg_patch_dict, model))
         print("✅✅✅✅✅✅ Cleaned Edges:", cleaned_patch_txt)
 
-        edges_patch = json.loads(_extract_json_block(cleaned_patch_txt)).get("edges_patch", [])
+        try:
+            edges_patch = json.loads(_extract_json_block(cleaned_patch_txt)).get("edges_patch", [])
+        except ValueError as e:
+            print(f"⚠️ Could not parse cleaned edges JSON: {e}")
+            edges_patch = []
 
         sentence_kg = {
             "sentence": sentence,


### PR DESCRIPTION
## Summary
- add error handling when ontology generation returns invalid or empty JSON
- avoid crashing when cleaned edge data is malformed by defaulting to empty edges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689201a15e80832ca2b879f7d1360339