### PR TITLE
chore: add sentence-transformers dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -31,6 +31,7 @@ spacy-transformers~=1.3            # (sometimes installed automatically, but be 
 # (hosted only on GitHub, so pin by URL)
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 torch>=2.2,<3                      # CPU or CUDA wheel resolved at install
+sentence-transformers>=3,<4        # sentence embedding models
 python-dotenv>=1,<2                # load .env files
 requests~=2.32
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -245,7 +245,9 @@ jinja2==3.1.6
 jinja2-humanize-extension==0.4.0
     # via prefect
 joblib==1.5.1
-    # via nltk
+    # via
+    #   nltk
+    #   scikit-learn
 jsonpatch==1.33
     # via
     #   langchain-core
@@ -630,10 +632,18 @@ safetensors==0.5.3
     #   accelerate
     #   timm
     #   transformers
+scikit-learn==1.5.2
+    # via sentence-transformers
 scipy==1.15.3
-    # via unstructured-inference
+    # via
+    #   scikit-learn
+    #   unstructured-inference
 semver==3.0.4
     # via prefect
+sentence-transformers==3.0.1
+    # via -r requirements.in
+sentencepiece==0.2.0
+    # via sentence-transformers
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -692,6 +702,8 @@ text-unidecode==1.3
     # via python-slugify
 thinc==8.3.4
     # via spacy
+threadpoolctl==3.5.0
+    # via scikit-learn
 timm==1.0.19
     # via
     #   effdet


### PR DESCRIPTION
## Summary
- include sentence-transformers in project requirements to support topic embeddings
- record scikit-learn and other transitive dependencies

## Testing
- `python -m py_compile transformation/convert.py`
- `pip install pip-tools` *(fails: Could not find a version that satisfies the requirement pip-tools)*

------
https://chatgpt.com/codex/tasks/task_e_689b2124afdc832c9d5ccbfe0d5c566f