### PR TITLE
fix: escape neo4j metadata names

### DIFF
--- a/transformation/doc_tree.py
+++ b/transformation/doc_tree.py
@@ -234,9 +234,15 @@ def clear_neo4j(uri: str, user: str, password: str, drop_meta: bool = False) -> 
         sess.run("MATCH (n) DETACH DELETE n")
         if drop_meta:
             for rec in sess.run("SHOW CONSTRAINTS"):
-                sess.run(f"DROP CONSTRAINT {rec['name']} IF EXISTS")
+                name = rec["name"]
+                if name:
+                    # Backticks allow dropping constraints with hyphenated names
+                    sess.run(f"DROP CONSTRAINT `{name}` IF EXISTS")
             for rec in sess.run("SHOW INDEXES"):
-                sess.run(f"DROP INDEX {rec['name']} IF EXISTS")
+                name = rec["name"]
+                if name:
+                    # Backticks escape special characters in index names
+                    sess.run(f"DROP INDEX `{name}` IF EXISTS")
     driver.close()
     log("✅ Database cleared")
 

--- a/transformation/run_pipeline.py
+++ b/transformation/run_pipeline.py
@@ -52,9 +52,16 @@ def clear_database(drop_meta: bool = False) -> None:
         sess.run("MATCH (n) DETACH DELETE n")
         if drop_meta:
             for rec in sess.run("SHOW CONSTRAINTS"):
-                sess.run(f"DROP CONSTRAINT {rec['name']} IF EXISTS")
+                name = rec["name"]
+                if name:
+                    # Use backticks so constraint names with special characters
+                    # (e.g. hyphens) are parsed correctly by Neo4j
+                    sess.run(f"DROP CONSTRAINT `{name}` IF EXISTS")
             for rec in sess.run("SHOW INDEXES"):
-                sess.run(f"DROP INDEX {rec['name']} IF EXISTS")
+                name = rec["name"]
+                if name:
+                    # Same treatment for index names; backticks escape hyphens
+                    sess.run(f"DROP INDEX `{name}` IF EXISTS")
 
 def _chunk(iterable, size):
     it = iter(iterable)


### PR DESCRIPTION
## Summary
- ensure indexes and constraints with hyphenated names are dropped correctly by wrapping in backticks
- apply same escaping in doc_tree utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b2eda7750832c8f2d59c04c84175e