### PR TITLE
Default to OpenAI LLM

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,6 +17,7 @@ prefect~=3.4                 # 2025-05-29 :contentReference[oaicite:3]{index=3}
  langchain-community>=0.3,<0.4
  langchain-ollama>=0.2,<0.3          # 0.2.x requires core 0.3
  langchain-google-genai>=2,<3        # 2.x requires core 0.3
+ langchain-openai>=0.1,<0.2
 
 # ---- transient compatibility pins ----
 packaging<24      # many libs still cap here

--- a/transformation/llm.py
+++ b/transformation/llm.py
@@ -5,13 +5,13 @@ from typing import Any
 def build_llm() -> Any:
     """Return an LLM instance based on environment configuration.
 
-    Defaults to using Google's Gemini models. Set the environment variable
-    ``LLM_PROVIDER`` to ``"ollama"`` to use an Ollama-backed model instead.
-    For Gemini, the API key is read from ``GEMINI_API_KEY`` or
-    ``GOOGLE_API_KEY``. For Ollama, ``OLLAMA_HOST`` or ``OLLAMA_HOST_PC`` must
-    be set.
+    Defaults to OpenAI models. Set ``LLM_PROVIDER`` to ``"google"`` or
+    ``"ollama"`` to use Gemini or an Ollama-backed model instead. For OpenAI,
+    the API key is read from ``OPENAI_API_KEY``. For Gemini, the API key is
+    read from ``GEMINI_API_KEY`` or ``GOOGLE_API_KEY``. For Ollama,
+    ``OLLAMA_HOST`` or ``OLLAMA_HOST_PC`` must be set.
     """
-    provider = os.getenv("LLM_PROVIDER", "google").lower()
+    provider = os.getenv("LLM_PROVIDER", "openai").lower()
 
     if provider == "ollama":
         from langchain_ollama.llms import OllamaLLM
@@ -27,10 +27,19 @@ def build_llm() -> Any:
             temperature=0.0,
         )
 
-    from langchain_google_genai import GoogleGenerativeAI
+    if provider == "google":
+        from langchain_google_genai import GoogleGenerativeAI
 
-    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            raise EnvironmentError("Set GEMINI_API_KEY or GOOGLE_API_KEY")
+        model_name = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash")
+        return GoogleGenerativeAI(model=model_name, google_api_key=api_key, temperature=0.0)
+
+    from langchain_openai import ChatOpenAI
+
+    api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
-        raise EnvironmentError("Set GEMINI_API_KEY or GOOGLE_API_KEY")
-    model_name = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash")
-    return GoogleGenerativeAI(model=model_name, google_api_key=api_key, temperature=0.0)
+        raise EnvironmentError("Set OPENAI_API_KEY")
+    model_name = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+    return ChatOpenAI(model=model_name, api_key=api_key, temperature=0.0)


### PR DESCRIPTION
## Summary
- default LLM provider switched to OpenAI, reading model and API key from env vars
- allow selecting Google or Ollama via `LLM_PROVIDER`
- add `langchain-openai` dependency

## Testing
- `python -m py_compile transformation/llm.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dd47cb294832cb2e544680b0e91bd