### PR TITLE
Use Azure OpenAI client

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ prefect~=3.4                 # 2025-05-29 :contentReference[oaicite:3]{index=3}
  langchain-community>=0.3,<0.4
  langchain-ollama>=0.2,<0.3          # 0.2.x requires core 0.3
  langchain-google-genai>=2,<3        # 2.x requires core 0.3
- langchain-openai>=0.2,<0.3
+ openai>=1,<2
 
 # ---- transient compatibility pins ----
 packaging<24      # many libs still cap here

--- a/requirements.txt
+++ b/requirements.txt
@@ -278,13 +278,10 @@ langchain-core==0.3.72
     #   langchain-community
     #   langchain-google-genai
     #   langchain-ollama
-    #   langchain-openai
     #   langchain-text-splitters
 langchain-google-genai==2.1.9
     # via -r requirements.in
 langchain-ollama==0.2.3
-    # via -r requirements.in
-langchain-openai==0.2.14
     # via -r requirements.in
 langchain-text-splitters==0.3.9
     # via langchain
@@ -389,7 +386,7 @@ onnxruntime==1.22.1
     #   unstructured
     #   unstructured-inference
 openai==1.99.9
-    # via langchain-openai
+    # via -r requirements.in
 opencv-python==4.11.0.86
     # via unstructured-inference
 openpyxl==3.1.5
@@ -722,7 +719,7 @@ thinc==8.3.4
 threadpoolctl==3.6.0
     # via scikit-learn
 tiktoken==0.11.0
-    # via langchain-openai
+    # via openai
 timm==1.0.19
     # via
     #   effdet

--- a/transformation/llm.py
+++ b/transformation/llm.py
@@ -2,14 +2,35 @@ import os
 from typing import Any
 
 
+class _ChatCompletionWrapper:
+    """Minimal interface over the OpenAI client exposing ``invoke``."""
+
+    def __init__(self, client, model: str, *, temperature: float = 0.0, max_tokens: int = 1000) -> None:
+        self._client = client
+        self._model = model
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+
+    def invoke(self, prompt: str) -> str:
+        response = self._client.chat.completions.create(
+            model=self._model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=self._temperature,
+            max_tokens=self._max_tokens,
+        )
+        return response.choices[0].message.content
+
+
 def build_llm() -> Any:
     """Return an LLM instance based on environment configuration.
 
     Defaults to OpenAI models. Set ``LLM_PROVIDER`` to ``"google"`` or
     ``"ollama"`` to use Gemini or an Ollama-backed model instead. For OpenAI,
-    the API key is read from ``OPENAI_API_KEY``. For Gemini, the API key is
-    read from ``GEMINI_API_KEY`` or ``GOOGLE_API_KEY``. For Ollama,
-    ``OLLAMA_HOST`` or ``OLLAMA_HOST_PC`` must be set.
+    the API key is read from ``OPENAI_API_KEY`` and the endpoint from
+    ``OPENAI_ENDPOINT`` (or ``AZURE_OPENAI_ENDPOINT``); ``OPENAI_API_VERSION``
+    may also be set. For Gemini, the API key is read from ``GEMINI_API_KEY``
+    or ``GOOGLE_API_KEY``. For Ollama, ``OLLAMA_HOST`` or ``OLLAMA_HOST_PC``
+    must be set.
     """
     provider = os.getenv("LLM_PROVIDER", "openai").lower()
 
@@ -36,10 +57,20 @@ def build_llm() -> Any:
         model_name = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash")
         return GoogleGenerativeAI(model=model_name, google_api_key=api_key, temperature=0.0)
 
-    from langchain_openai import ChatOpenAI
+    from openai import AzureOpenAI
 
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise EnvironmentError("Set OPENAI_API_KEY")
+    endpoint = os.environ.get("OPENAI_ENDPOINT") or os.environ.get("AZURE_OPENAI_ENDPOINT")
+    if not endpoint:
+        raise EnvironmentError("Set OPENAI_ENDPOINT or AZURE_OPENAI_ENDPOINT")
+    api_version = os.environ.get("OPENAI_API_VERSION", "2024-02-15-preview")
     model_name = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
-    return ChatOpenAI(model=model_name, api_key=api_key, temperature=0.0)
+
+    client = AzureOpenAI(
+        azure_endpoint=endpoint,
+        api_key=api_key,
+        api_version=api_version,
+    )
+    return _ChatCompletionWrapper(client, model_name, temperature=0.0)


### PR DESCRIPTION
## Summary
- Replace LangChain OpenAI usage with direct Azure OpenAI client and lightweight wrapper exposing an `invoke` method
- Drop `langchain-openai` dependency and add `openai` package

## Testing
- `python -m py_compile transformation/llm.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a30c0ce47c832cbe8a44083e617046