### PR TITLE
Normalize relation names for Neo4j

### DIFF
--- a/transformation/convert.py
+++ b/transformation/convert.py
@@ -1,10 +1,20 @@
 import json
+import re
 from pathlib import Path
 
 from sentence_transformers import SentenceTransformer
 
-def clean_relation(s):
-    return s.upper().replace(" ", "_").replace("-", "_")
+
+def clean_relation(s: str) -> str:
+    """Normalize relation and label names for Cypher.
+
+    Neo4j relationship types and labels may only contain alphanumeric
+    characters and underscores. Any other character (including punctuation
+    like curly apostrophes) is replaced with an underscore and the result is
+    uppercased.
+    """
+
+    return re.sub(r"[^0-9A-Z_]", "_", s.upper())
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 


### PR DESCRIPTION
## Summary
- Sanitize relationship and label names for Cypher by replacing non-alphanumeric characters with underscores.
- Document the normalization behaviour and ensure uppercase output.

## Testing
- `python -m py_compile transformation/convert.py transformation/run_pipeline.py`
- `pytest`
- `pip install sentence-transformers` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a44c0bf55c832c82b0f2a72c9d6128