### PR TITLE
Centralize env loading and reuse Cypher conversion helpers

### DIFF
--- a/env.py
+++ b/env.py
@@ -1,0 +1,5 @@
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:  # pragma: no cover
+    pass

--- a/transformation/convert.py
+++ b/transformation/convert.py
@@ -32,6 +32,56 @@ DEFAULT_OUTPUT = STRUCTURED_DIR / "import_kg.cypher"
 model = SentenceTransformer("all-MiniLM-L6-v2")
 
 
+def node_to_cypher(node: dict) -> str:
+    """Return a ``CREATE`` statement for *node* with optional embedding."""
+
+    nid = node["id"]
+    label = node["label"]
+    props = {k: v for k, v in node.items() if k not in ["id", "label", "type"]}
+    if "attributes" in props:
+        attrs = props.pop("attributes")
+        props.update(attrs)
+
+    node_label = node.get("type", "Entity")
+
+    if node_label == "Topic":
+        embedding = model.encode(node.get("label", "")).tolist()
+        props["embedding"] = embedding
+
+    prop_str = ""
+    if props:
+        pairs = [
+            f'{k}: "{v}"' if isinstance(v, str) else f'{k}: {v}'
+            for k, v in props.items()
+        ]
+        prop_str = ", " + ", ".join(pairs)
+
+    return (
+        f'CREATE (:{clean_relation(node_label)} '
+        f'{{id: "{nid}", label: "{label}"{prop_str}}});'
+    )
+
+
+def edge_to_cypher(edge: dict) -> str:
+    """Return Cypher statements to connect two nodes."""
+
+    src = edge["source"]
+    tgt = edge["target"]
+    rel = clean_relation(escape(edge["relation"]))
+    attr_str = ""
+    if edge.get("attributes"):
+        pairs = [
+            f'{k}: "{v}"' if isinstance(v, str) else f'{k}: {v}'
+            for k, v in edge["attributes"].items()
+        ]
+        attr_str = " { " + ", ".join(pairs) + " }"
+
+    return (
+        f"MATCH (a {{id: \"{src}\"}}), (b {{id: \"{tgt}\"}})\n"
+        f"CREATE (a)-[:{rel}{attr_str}]->(b);"
+    )
+
+
 def final_to_cypher(input: Path = DEFAULT_INPUT, output: Path = DEFAULT_OUTPUT) -> None:
     """Convert ``final_kg.json`` to ``import_kg.cypher`` with embeddings."""
 
@@ -41,63 +91,16 @@ def final_to_cypher(input: Path = DEFAULT_INPUT, output: Path = DEFAULT_OUTPUT) 
     cypher_nodes: list[str] = []
     cypher_edges: list[str] = []
 
-    # Use a set to track all created nodes (avoid duplicate CREATEs)
     node_ids: set[str] = set()
-
     for node in kg["nodes"]:
-        nid = node["id"]
-        label = node["label"]
-
-        # Avoid duplicating the same node
-        if nid in node_ids:
+        if node["id"] in node_ids:
             continue
-        node_ids.add(nid)
-
-        props = {k: v for k, v in node.items() if k not in ["id", "label", "type"]}
-        # Also handle nested attributes
-        if "attributes" in props:
-            attrs = props.pop("attributes")
-            props.update(attrs)
-
-        node_label = node.get("type", "Entity")
-
-        # Add embedding for Topic nodes
-        if node_label == "Topic":
-            embedding = model.encode(node.get("label", "")).tolist()
-            props["embedding"] = embedding
-
-        prop_str = ""
-        if props:
-            prop_pairs = [
-                f'{k}: "{v}"' if isinstance(v, str) else f'{k}: {v}'
-                for k, v in props.items()
-            ]
-            prop_str = ", " + ", ".join(prop_pairs)
-
-        cypher_nodes.append(
-            f'CREATE (:{clean_relation(node_label)} {{id: "{nid}", label: "{label}"{prop_str}}});'
-        )
+        node_ids.add(node["id"])
+        cypher_nodes.append(node_to_cypher(node))
 
     for edge in kg["edges"]:
-        src = edge["source"]
-        tgt = edge["target"]
-        rel = clean_relation(escape(edge["relation"]))
-        attr_str = ""
-        if "attributes" in edge and edge["attributes"]:
-            attr_pairs = [
-                f'{k}: "{v}"' if isinstance(v, str) else f'{k}: {v}'
-                for k, v in edge["attributes"].items()
-            ]
-            attr_str = " { " + ", ".join(attr_pairs) + " }"
+        cypher_edges.append(edge_to_cypher(edge))
 
-        cypher_edges.append(
-            f"""
-MATCH (a {{id: \"{src}\"}}), (b {{id: \"{tgt}\"}})
-CREATE (a)-[:{rel}{attr_str}]->(b);
-"""
-        )
-
-    # Write Cypher script to file
     with open(output, "w", encoding="utf-8") as f:
         f.write("\n".join(cypher_nodes + cypher_edges))
 

--- a/transformation/doc_tree.py
+++ b/transformation/doc_tree.py
@@ -11,13 +11,8 @@ from pathlib import Path
 from typing import List
 from uuid import uuid4
 
-try:
-    # load environment variables from .env file (requires `python-dotenv`)
-    from dotenv import load_dotenv
-
-    load_dotenv()
-except ImportError:  # pragma: no cover - optional dependency
-    pass
+# Load environment variables once on import
+import env  # noqa: F401
 
 os.environ["OLLAMA_HOST"] = os.environ.get(
     "OLLAMA_HOST_PC", os.environ.get("OLLAMA_HOST", "")

--- a/transformation/pipeline.py
+++ b/transformation/pipeline.py
@@ -18,13 +18,8 @@ from LLMs import (
 )
 from llm import build_llm
 
-try:
-    # load environment variables from .env file (requires `python-dotenv`)
-    from dotenv import load_dotenv
-
-    load_dotenv()
-except ImportError:
-    pass
+# Load environment variables once on import
+import env  # noqa: F401
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 STRUCTURED_DIR = BASE_DIR / "structured"

--- a/transformation/run_pipeline.py
+++ b/transformation/run_pipeline.py
@@ -3,8 +3,9 @@ import json, itertools
 from neo4j import GraphDatabase
 from contextlib import ExitStack
 from pathlib import Path
-from convert import clean_relation, escape               # reuse your helpers
+from convert import edge_to_cypher, node_to_cypher
 import pathlib
+import env  # noqa: F401
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 KG_PATH   = BASE_DIR / "structured" / "final_kg.json"
@@ -13,20 +14,15 @@ BOLT_URI  = "bolt://localhost:7687"
 driver    = GraphDatabase.driver(BOLT_URI, auth=("neo4j", "12345678"))
 
 def kg_to_statements(kg):
-    for n in kg["nodes"]:
-        props = {k: v for k, v in n.items() if k not in ("id", "label")}
-        if "attributes" in props:
-            props.update(props.pop("attributes"))
-        prop_str = ", ".join(f'{k}: {json.dumps(v)}' for k, v in props.items())
-        yield f'CREATE (:Entity {{id: "{n["id"]}", label: "{escape(n["label"])}"{", " + prop_str if prop_str else ""}}});'
+    node_ids = set()
+    for node in kg["nodes"]:
+        if node["id"] in node_ids:
+            continue
+        node_ids.add(node["id"])
+        yield node_to_cypher(node)
 
-    for e in kg["edges"]:
-        attr = e.get("attributes") or {}
-        a_str = (" { " + ", ".join(f'{k}: {json.dumps(v)}' for k, v in attr.items()) + " }") if attr else ""
-        yield (
-            f'MATCH (a {{id: "{e["source"]}"}}), (b {{id: "{e["target"]}"}}) '
-            f'CREATE (a)-[:{clean_relation(escape(e["relation"]))}{a_str}]->(b);'
-        )
+    for edge in kg["edges"]:
+        yield edge_to_cypher(edge)
 
 def load_and_push(save_to: Path | None = None) -> None:
     kg     = json.loads(KG_PATH.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- Add `env.py` that loads `.env` on import
- Replace scattered `load_dotenv` calls with `import env`
- Extract `node_to_cypher` and `edge_to_cypher` helpers and use them in `run_pipeline`

## Testing
- `pytest`
- `python -m py_compile env.py transformation/pipeline.py transformation/doc_tree.py transformation/convert.py transformation/run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6eb6b2edc832c92a75ca1ac398ffa