### PR TITLE
refactor: centralize Neo4j reset and text extraction

### DIFF
--- a/ingestion/ingestion.py
+++ b/ingestion/ingestion.py
@@ -30,7 +30,7 @@ from typing import List
 from unstructured.partition.auto import partition
 from unstructured.chunking.basic import chunk_elements
 from unstructured.documents.elements import Element
-import pdfplumber
+from utils.io import extract_text
 
 logger = logging.getLogger(__name__)
 
@@ -106,20 +106,6 @@ def write_output(elements: List[Element], out: Path | None, src: Path) -> None:
     records = [el.to_dict() for el in elements]
     out.write_text(json.dumps(records, indent=2, ensure_ascii=False), encoding="utf-8")
     logger.info("Wrote %d elements ➜ %s", len(records), out)
-
-
-def extract_text(path: Path) -> str:
-    """Return plain text extracted from *path*.
-
-    Currently supports PDF via pdfplumber; other files are read as UTF-8.
-    """
-    if path.suffix.lower() == ".pdf":
-        with pdfplumber.open(path) as pdf:
-            pages = [page.extract_text() or "" for page in pdf.pages]
-        return "\n".join(pages)
-
-    return path.read_text(encoding="utf-8")
-
 
 def ingest_directory(input_dir: Path, output_file: Path, verbose: bool = False) -> None:
     """Ingest all PDFs from *input_dir* and write combined text to *output_file*."""

--- a/neo4j_utils.py
+++ b/neo4j_utils.py
@@ -1,0 +1,18 @@
+from neo4j import GraphDatabase
+
+
+def clear_database(uri: str, user: str, password: str, drop_meta: bool = False) -> None:
+    """Delete all nodes and optionally indexes/constraints from Neo4j."""
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    with driver.session() as sess:
+        sess.run("MATCH (n) DETACH DELETE n")
+        if drop_meta:
+            for rec in sess.run("SHOW CONSTRAINTS"):
+                name = rec["name"]
+                if name:
+                    sess.run(f"DROP CONSTRAINT `{name}` IF EXISTS")
+            for rec in sess.run("SHOW INDEXES"):
+                name = rec["name"]
+                if name:
+                    sess.run(f"DROP INDEX `{name}` IF EXISTS")
+    driver.close()

--- a/transformation/doc_tree.py
+++ b/transformation/doc_tree.py
@@ -19,10 +19,11 @@ os.environ["OLLAMA_HOST"] = os.environ.get(
 )
 
 import nltk
-import pdfplumber
 from neo4j import GraphDatabase
 from llm import build_llm
 from LLMs import label_text, sentence_topic_same, clean_label
+from utils.io import extract_text
+from neo4j_utils import clear_database
 
 VERBOSE = False
 
@@ -47,22 +48,6 @@ def get_context_window(model) -> int:
     else:
         key = getattr(model, "model", "")
     return known.get(key, 8192)
-
-
-def extract_text(path: Path) -> str:
-    """Return plain text from *path*.
-
-    Supports PDF via ``pdfplumber`` or reads the file as UTF-8 text otherwise.
-    """
-    if path.suffix.lower() == ".pdf":
-        with pdfplumber.open(path) as pdf:
-            pages = [page.extract_text() or "" for page in pdf.pages]
-        return "\n".join(pages)
-
-    return path.read_text(encoding="utf-8")
-
-
-
 # ---------------------------------------------------------------------------
 # Node class
 # ---------------------------------------------------------------------------
@@ -221,27 +206,6 @@ def push_to_neo4j(root: Node, uri: str, user: str, password: str) -> None:
     log("✅ Finished pushing to Neo4j")
 
 
-def clear_neo4j(uri: str, user: str, password: str, drop_meta: bool = False) -> None:
-    """Delete all nodes and optionally indexes/constraints from Neo4j."""
-    log(f"🗑️  Clearing Neo4j at {uri}")
-    driver = GraphDatabase.driver(uri, auth=(user, password))
-    with driver.session() as sess:
-        sess.run("MATCH (n) DETACH DELETE n")
-        if drop_meta:
-            for rec in sess.run("SHOW CONSTRAINTS"):
-                name = rec["name"]
-                if name:
-                    # Backticks allow dropping constraints with hyphenated names
-                    sess.run(f"DROP CONSTRAINT `{name}` IF EXISTS")
-            for rec in sess.run("SHOW INDEXES"):
-                name = rec["name"]
-                if name:
-                    # Backticks escape special characters in index names
-                    sess.run(f"DROP INDEX `{name}` IF EXISTS")
-    driver.close()
-    log("✅ Database cleared")
-
-
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -297,7 +261,7 @@ def main() -> None:
     log(f"💾 Writing tree to {args.out}")
     Path(args.out).write_text(json.dumps(tree.to_dict(), indent=2), encoding="utf-8")
     if args.reset_db:
-        clear_neo4j(args.neo4j_uri, args.neo4j_user, args.neo4j_pass, drop_meta=True)
+        clear_database(args.neo4j_uri, args.neo4j_user, args.neo4j_pass, drop_meta=True)
     push_to_neo4j(tree, args.neo4j_uri, args.neo4j_user, args.neo4j_pass)
 
 

--- a/transformation/pipeline.py
+++ b/transformation/pipeline.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Dict, Any, Iterable
 import spacy, warnings
 import argparse
-import pdfplumber
 from kg_utils import _extract_json_block, update_kg, clean_kg
 from LLMs import (
     simplify_text,
@@ -17,6 +16,7 @@ from LLMs import (
     clean_label,
 )
 from llm import build_llm
+from utils.io import extract_text
 
 # Load environment variables once on import
 import env  # noqa: F401
@@ -58,19 +58,6 @@ def ensure_final_kg_exists() -> None:
         except Exception:
             pass
     FINAL_KG_PATH.write_text(json.dumps({"nodes": [], "edges": []}, indent=2))
-
-
-def extract_text(path: Path) -> str:
-    """Return plain text extracted from *path*.
-
-    Currently supports PDF via pdfplumber; other files are read as UTF-8.
-    """
-    if path.suffix.lower() == ".pdf":
-        with pdfplumber.open(path) as pdf:
-            pages = [page.extract_text() or "" for page in pdf.pages]
-        return "\n".join(pages)
-
-    return path.read_text(encoding="utf-8")
 
 
 def prepare_input_file(src: Path, dest: Path = STRUCTURED_DIR / "output.json") -> str:

--- a/transformation/run_pipeline.py
+++ b/transformation/run_pipeline.py
@@ -6,12 +6,15 @@ from pathlib import Path
 from convert import edge_to_cypher, node_to_cypher
 import pathlib
 import env  # noqa: F401
+from neo4j_utils import clear_database
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 KG_PATH   = BASE_DIR / "structured" / "final_kg.json"
 OUT_PATH  = BASE_DIR / "structured" / "import_kg.cypher"
-BOLT_URI  = "bolt://localhost:7687"
-driver    = GraphDatabase.driver(BOLT_URI, auth=("neo4j", "12345678"))
+BOLT_URI   = "bolt://localhost:7687"
+NEO4J_USER = "neo4j"
+NEO4J_PASS = "12345678"
+driver     = GraphDatabase.driver(BOLT_URI, auth=(NEO4J_USER, NEO4J_PASS))
 
 def kg_to_statements(kg):
     node_ids = set()
@@ -78,28 +81,12 @@ def push_cypher_file(path: Path) -> None:
 
         tx.commit()
 
-def clear_database(drop_meta: bool = False) -> None:
-    with driver.session() as sess:
-        sess.run("MATCH (n) DETACH DELETE n")
-        if drop_meta:
-            for rec in sess.run("SHOW CONSTRAINTS"):
-                name = rec["name"]
-                if name:
-                    # Use backticks so constraint names with special characters
-                    # (e.g. hyphens) are parsed correctly by Neo4j
-                    sess.run(f"DROP CONSTRAINT `{name}` IF EXISTS")
-            for rec in sess.run("SHOW INDEXES"):
-                name = rec["name"]
-                if name:
-                    # Same treatment for index names; backticks escape hyphens
-                    sess.run(f"DROP INDEX `{name}` IF EXISTS")
-
 def _chunk(iterable, size):
     it = iter(iterable)
     for first in it:
         yield list(itertools.chain([first], itertools.islice(it, size-1)))
 
 if __name__ == "__main__":
-    clear_database(drop_meta=True)           # wipe
+    clear_database(BOLT_URI, NEO4J_USER, NEO4J_PASS, drop_meta=True)  # wipe
     load_and_push(save_to=OUT_PATH)          # reload + save copy
     print("✅ Graph ingested and written to", OUT_PATH)

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import pdfplumber
+
+
+def extract_text(path: Path) -> str:
+    """Return plain text extracted from *path*.
+
+    Supports PDF via pdfplumber; other files are read as UTF-8.
+    """
+    if path.suffix.lower() == ".pdf":
+        with pdfplumber.open(path) as pdf:
+            pages = [page.extract_text() or "" for page in pdf.pages]
+        return "\n".join(pages)
+
+    return path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add shared `clear_database` helper for Neo4j cleanup
- consolidate PDF/text reading into `utils.io.extract_text`
- update pipeline, doc tree, ingestion, and run pipeline scripts to use new utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6ed3fa958832cb22e1dfb51ca89b4