### PR TITLE
Load Neo4j credentials from environment

### DIFF
--- a/merging/pipeline.py
+++ b/merging/pipeline.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Tuple
+import os
 import re
+import env  # noqa: F401
 
 
 # ---------------------------------------------------------------------------
@@ -85,10 +87,17 @@ def query_similar_topics(
     index_name: str = "topic-embeddings",
     top_k: int = 5,
     uri: str = "bolt://localhost:7687",
-    auth: Tuple[str, str] = ("neo4j", "12345678"),
+    auth: Tuple[str, str] | None = None,
 ) -> List[Tuple[Topic, List[dict]]]:
     """Return a list of ``(topic, matches)`` pairs."""
     from neo4j import GraphDatabase
+
+    if auth is None:
+        user = os.environ.get("NEO4J_USER")
+        password = os.environ.get("NEO4J_PASS")
+        if not user or not password:
+            raise RuntimeError("NEO4J_USER and NEO4J_PASS must be set")
+        auth = (user, password)
 
     driver = GraphDatabase.driver(uri, auth=auth)
     results: List[Tuple[Topic, List[dict]]] = []

--- a/transformation/doc_tree.py
+++ b/transformation/doc_tree.py
@@ -225,8 +225,8 @@ def parse_args() -> argparse.Namespace:
         help="Model name for the provider",
     )
     p.add_argument("--neo4j-uri", default="bolt://localhost:7687")
-    p.add_argument("--neo4j-user", default="neo4j")
-    p.add_argument("--neo4j-pass", default="neo4j")
+    p.add_argument("--neo4j-user", default=os.environ.get("NEO4J_USER"))
+    p.add_argument("--neo4j-pass", default=os.environ.get("NEO4J_PASS"))
     p.add_argument("--out", default="topic_tree.json")
     p.add_argument(
         "--reset-db",

--- a/transformation/run_pipeline.py
+++ b/transformation/run_pipeline.py
@@ -1,20 +1,27 @@
 # run_pipeline.py
 import json, itertools
+import os
 from neo4j import GraphDatabase
 from contextlib import ExitStack
 from pathlib import Path
 from convert import edge_to_cypher, node_to_cypher
 import pathlib
 import env  # noqa: F401
-from neo4j_utils import clear_database
+from neo4j_utils import clear_database as _clear_database
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 KG_PATH   = BASE_DIR / "structured" / "final_kg.json"
 OUT_PATH  = BASE_DIR / "structured" / "import_kg.cypher"
-BOLT_URI   = "bolt://localhost:7687"
-NEO4J_USER = "neo4j"
-NEO4J_PASS = "12345678"
-driver     = GraphDatabase.driver(BOLT_URI, auth=(NEO4J_USER, NEO4J_PASS))
+BOLT_URI = "bolt://localhost:7687"
+NEO4J_USER = os.environ.get("NEO4J_USER")
+NEO4J_PASS = os.environ.get("NEO4J_PASS")
+if not NEO4J_USER or not NEO4J_PASS:
+    raise RuntimeError("NEO4J_USER and NEO4J_PASS must be set")
+driver = GraphDatabase.driver(BOLT_URI, auth=(NEO4J_USER, NEO4J_PASS))
+
+
+def clear_database(*, drop_meta: bool = False) -> None:
+    _clear_database(BOLT_URI, NEO4J_USER, NEO4J_PASS, drop_meta=drop_meta)
 
 def kg_to_statements(kg):
     node_ids = set()
@@ -87,6 +94,6 @@ def _chunk(iterable, size):
         yield list(itertools.chain([first], itertools.islice(it, size-1)))
 
 if __name__ == "__main__":
-    clear_database(BOLT_URI, NEO4J_USER, NEO4J_PASS, drop_meta=True)  # wipe
+    clear_database(drop_meta=True)  # wipe
     load_and_push(save_to=OUT_PATH)          # reload + save copy
     print("✅ Graph ingested and written to", OUT_PATH)


### PR DESCRIPTION
## Summary
- Load Neo4j username and password from environment variables instead of hardcoded strings in transformation scripts
- Allow doc_tree CLI and merging pipeline to default Neo4j credentials from environment
- Provide utility wrapper for Neo4j database clearing

## Testing
- `python -m py_compile transformation/run_pipeline.py transformation/doc_tree.py merging/pipeline.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6ef080a3c832c95e2e2a26f82efa2