### PR TITLE
Fix import path for transformation scripts

### DIFF
--- a/transformation/main.py
+++ b/transformation/main.py
@@ -1,6 +1,11 @@
 import json
 import argparse
 from pathlib import Path
+import sys
+
+# Ensure the project root is on the import path so sibling modules like
+# ``utils`` can be imported when this file is executed as a script.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from llm import build_llm
 


### PR DESCRIPTION
## Summary
- ensure `transformation/main.py` adds the project root to `sys.path` so `utils` can be imported when run as a script

## Testing
- `python transformation/main.py --help` *(fails: No module named 'spacy')*
- `pip install spacy` *(fails: Could not find a version that satisfies the requirement spacy)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f05b9620832c913c107d8c249472